### PR TITLE
Bump grpc package version from 1.48.0 to 1.49.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,14 +102,14 @@ ExternalProject_Add(curl
 ExternalProject_Add(grpc-repo
   PREFIX grpc-repo
   GIT_REPOSITORY "https://github.com/grpc/grpc.git"
-  GIT_TAG "v1.48.0"
+  GIT_TAG "v1.49.0"
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/grpc-repo/src/grpc"
   EXCLUDE_FROM_ALL ON
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
   TEST_COMMAND ""
-  PATCH_COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_src.py --src <SOURCE_DIR> ${INSTALL_SRC_DEST_ARG} --dest-basename=grpc_1.48.0
+  PATCH_COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_src.py --src <SOURCE_DIR> ${INSTALL_SRC_DEST_ARG} --dest-basename=grpc_1.49.0
 )
 
 #


### PR DESCRIPTION
This is to address a build error exists in grpc 1.48.0: xds_http_fault_filter.cc: In function ‘absl::lts_20220623::StatusOr<grpc_core::Json> grpc_core::{anonymous}::ParseHttpFaultIntoJson(upb_StringView, upb_Arena*)’: ./repo-third-party-build/grpc-repo/src/grpc/src/core/ext/xds/xds_http_fault_filter.cc:112:39: error: expected ‘)’ before ‘and’
       if (abort_http_status_code != 0 and abort_http_status_code != 200) {