### PR TITLE
Remove cherry-pick for protobuf inside grpc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ ExternalProject_Add(protobuf
     -DBUILD_SHARED_LIBS:STRING=no
     -DCMAKE_INSTALL_LIBDIR:STRING=lib
     -DCMAKE_INSTALL_PREFIX:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf
-  PATCH_COMMAND git cherry-pick -n f180289c4670ca1afde5865bb8a7f2b61a3efcc5
   DEPENDS grpc-repo
 )
 


### PR DESCRIPTION
The cherry-pick "git cherry-pick -n f180289c4670ca1afde5865bb8a7f2b61a3efcc5" is not needed since the grpc version has been bumped from 1.48.0 to 1.49.0.